### PR TITLE
Use sessions if given for long standing connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ A python connector for RRP Proxy
 from rrpproxy import RRPProxy
 proxy = RRPProxy('username', 'password')
 ```
+ 
+RRPProxy advises to use long standing connections. If you want to re-use the same Session:
+
+```
+import requests
+from rrpproxy import RRPProxy
+
+session = requests.Session()
+proxy = RRPProxy('username', 'password', session=session)
+```
 
 ## connect to sandbox
 ```

--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 class RRPProxy:
-    def __init__(self, username, password, use_test_environment=False, session=None):
+    def __init__(self, username, password, session=None, use_test_environment=False):
         self.session = session
         if not session:
             self.session = requests

--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -8,7 +8,11 @@ logger = logging.getLogger(__name__)
 
 
 class RRPProxy:
-    def __init__(self, username, password, use_test_environment=False):
+    def __init__(self, username, password, use_test_environment=False, session=None):
+        self.session = session
+        if not session:
+            self.session = requests
+
         self.query_params = {
             's_login': username,
             's_pw': password
@@ -28,7 +32,7 @@ class RRPProxy:
         query_dict['command'] = command
 
         try:
-            response = requests.get(self.api_url, params=query_dict)
+            response = self.session.get(self.api_url, params=query_dict)
             response.raise_for_status()
             return self.response_to_dict(response.text)
         except requests.ConnectionError:

--- a/tests/test_rrpproxy_init.py
+++ b/tests/test_rrpproxy_init.py
@@ -11,18 +11,18 @@ class TestRRPProxyInit(TestRRPProxyBase):
         self.assertEqual(self.proxy.query_params, {'s_login': self.username, 's_pw': self.password, 's_opmode': 'OTE'})
 
     def test_init_sets_correct_api_url_and_query_params_when_using_live_environment(self):
-        self.proxy = RRPProxy(self.username, self.password, False)
+        self.proxy = RRPProxy(self.username, self.password)
 
         self.assertEqual(self.proxy.api_url, 'https://api.rrpproxy.net/api/call.cgi')
         self.assertEqual(self.proxy.query_params, {'s_login': self.username, 's_pw': self.password})
 
     def test_init_sets_requests_as_session_if_no_session_is_given(self):
-        self.proxy = RRPProxy(self.username, self.password, False)
+        self.proxy = RRPProxy(self.username, self.password)
 
         self.assertEqual(self.proxy.session, requests)
 
     def test_init_sets_session_if_given(self):
         session = Session()
-        self.proxy = RRPProxy(self.username, self.password, False, session=session)
+        self.proxy = RRPProxy(self.username, self.password, session=session)
 
         self.assertEqual(self.proxy.session, session)

--- a/tests/test_rrpproxy_init.py
+++ b/tests/test_rrpproxy_init.py
@@ -1,3 +1,6 @@
+import requests
+from requests import Session
+
 from rrpproxy import RRPProxy
 from tests.test_rrpproxy_base import TestRRPProxyBase
 
@@ -12,3 +15,14 @@ class TestRRPProxyInit(TestRRPProxyBase):
 
         self.assertEqual(self.proxy.api_url, 'https://api.rrpproxy.net/api/call.cgi')
         self.assertEqual(self.proxy.query_params, {'s_login': self.username, 's_pw': self.password})
+
+    def test_init_sets_requests_as_session_if_no_session_is_given(self):
+        self.proxy = RRPProxy(self.username, self.password, False)
+
+        self.assertEqual(self.proxy.session, requests)
+
+    def test_init_sets_session_if_given(self):
+        session = Session()
+        self.proxy = RRPProxy(self.username, self.password, False, session=session)
+
+        self.assertEqual(self.proxy.session, session)

--- a/tests/test_rrproxy_call.py
+++ b/tests/test_rrproxy_call.py
@@ -7,18 +7,18 @@ from tests.test_rrpproxy_base import TestRRPProxyBase
 
 
 class TestRRPProxyCall(TestRRPProxyBase):
-    def test_call_calls_request_get_with_correct_url_and_parameters(self):
+    def test_call_calls_session_get_with_correct_url_and_parameters(self):
         query_params = self.proxy.query_params.copy()
         query_params.update({'some_parameter': 'some_value', 'other_parameter': 'other_value', 'command': 'CheckDomain'})
 
         self.proxy.call('CheckDomain', some_parameter='some_value', other_parameter='other_value')
 
-        self.get_mock.assert_called_once_with(self.proxy.api_url, params=query_params)
+        self.proxy.session.get.assert_called_once_with(self.proxy.api_url, params=query_params)
 
     def test_call_calls_response_raise_for_status(self):
         self.proxy.call('CheckDomain', some_parameter='some_value', other_parameter='other_value')
 
-        self.get_mock.return_value.raise_for_status.assert_called_once_with()
+        self.proxy.session.get.return_value.raise_for_status.assert_called_once_with()
 
     def test_call_raises_rrpproxy_api_down_exception_when_there_is_a_connection_error(self):
         self.get_mock.side_effect = requests.ConnectionError


### PR DESCRIPTION
RRPProxy advises using long-standing connections: https://wiki.rrpproxy.net/api/epp-server/frequently-asked-questions.

Now you can do this in order to use a given session:
```python
import requests
from rrpproxy import RRPProxy

session = requests.Session()
proxy = RRPProxy('username', 'password', session=session)
```

If you don't want to use this, it will default to `requests` which will open and close connections automatically.
Note that you still have to keep the session open yourself if you remain inactive for too long.