### PR TITLE
Include space and '-' in property regex

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -43,7 +43,7 @@ class RRPProxy:
             key = response_line.split('=')[0].strip()
             value = response_line.split('=')[1].strip()
             if 'property[' in key:
-                property_key = re.search(r"property\[([A-Za-z0-9_]+)\]", key).group(1)
+                property_key = re.search(r"property\[([A-Za-z0-9_ -]+)\]", key).group(1)
                 if 'property' not in response_dict:
                     response_dict['property'] = {}
                 if property_key not in response_dict['property']:

--- a/tests/test_rrpproxy_response_to_dict.py
+++ b/tests/test_rrpproxy_response_to_dict.py
@@ -4,6 +4,7 @@ from tests.test_rrpproxy_base import TestRRPProxyBase
 
 
 class TestRRPProxyResponseToDict(TestRRPProxyBase):
+
     def test_response_to_dict_returns_a_dict_of_each_line_of_response_without_response_line_and_eof(self):
         self.get_mock.return_value = MagicMock(text='[RESPONSE]\ncode = 210\ndescription = Domain name available\nruntime = 0.267\nqueuetime = 0\nEOF\n')
 
@@ -17,7 +18,19 @@ class TestRRPProxyResponseToDict(TestRRPProxyBase):
         })
 
     def test_response_to_dict_returns_dict_of_each_line_including_property_object(self):
-        self.get_mock.return_value = MagicMock(text='[RESPONSE]\ncode = 210\ndescription = Domain name available\nproperty[AMOUNT][0] = 100\nproperty[TYPE][0] = value\nruntime = 0.267\nqueuetime = 0\nEOF\n')
+        rrpproxy_response = "\n".join([
+            '[RESPONSE]',
+            'code = 210',
+            'description = Domain name available',
+            'property[AMOUNT][0] = 100',
+            'property[TYPE][0] = value',
+            'property[PARAMETER 0][0] = value 1',
+            'property[PARAMETER-1][0] = value-2',
+            'runtime = 0.267',
+            'queuetime = 0',
+            'EOF\n'
+        ])
+        self.get_mock.return_value = MagicMock(text=rrpproxy_response)
         response = self.proxy.call('Command', domain='hypernode.com')
 
         self.assertEqual(response, {
@@ -25,7 +38,9 @@ class TestRRPProxyResponseToDict(TestRRPProxyBase):
             'description': 'Domain name available',
             'property': {
                 'AMOUNT': ['100'],
-                'TYPE': ['value']
+                'TYPE': ['value'],
+                'PARAMETER 0': ['value 1'],
+                'PARAMETER-1': ['value-2'],
             },
             'runtime': '0.267',
             'queuetime': '0'


### PR DESCRIPTION
We need to match for spaces and dashes (-) as well in the regex.

Examples are `AFTERMARKET PROVIDER` and `X-DOMAIN-COMMENT` in https://wiki.rrpproxy.net/api/api-command/StatusDomain
