### PR TITLE
Cast response code to int

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -53,6 +53,8 @@ class RRPProxy:
                 if property_key not in response_dict['property']:
                     response_dict['property'][property_key] = []
                 response_dict['property'][property_key].append(value)
+            elif 'code' == key:
+                response_dict['code'] = int(value)
             else:
                 response_dict[key] = value
         return response_dict

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='rrpproxy',
-    version='0.0.5',
+    version='0.1.0',
     packages=find_packages(),
     include_package_data=True,
     description='A python connector for RRP Proxy',

--- a/tests/test_rrpproxy_response_to_dict.py
+++ b/tests/test_rrpproxy_response_to_dict.py
@@ -11,7 +11,7 @@ class TestRRPProxyResponseToDict(TestRRPProxyBase):
         response = self.proxy.call('CheckDomain', domain='hypernode.com')
 
         self.assertEqual(response, {
-            'code': '210',
+            'code': 210,
             'description': 'Domain name available',
             'runtime': '0.267',
             'queuetime': '0'
@@ -34,7 +34,7 @@ class TestRRPProxyResponseToDict(TestRRPProxyBase):
         response = self.proxy.call('Command', domain='hypernode.com')
 
         self.assertEqual(response, {
-            'code': '210',
+            'code': 210,
             'description': 'Domain name available',
             'property': {
                 'AMOUNT': ['100'],


### PR DESCRIPTION
Cast response.code to int: This makes a little more sense from a programming point of view. For example we can use comparison to see if a call was successful (>400 for example). Also this feels a little nicer and matches well with our status codes defined in utils/status_codes.py.

