### PR TITLE
Raise on 400 or higher

### DIFF
--- a/rrpproxy/utils/rrp_proxy_internal_status_exception.py
+++ b/rrpproxy/utils/rrp_proxy_internal_status_exception.py
@@ -1,0 +1,4 @@
+class RRPProxyInternalStatusException(Exception):
+    def __init__(self, *args, **kwargs):
+        self.code = kwargs.pop('code')
+        super(RRPProxyInternalStatusException, self).__init__(args, kwargs)

--- a/tests/utils/test_rrp_proxy_internal_status_exception.py
+++ b/tests/utils/test_rrp_proxy_internal_status_exception.py
@@ -1,0 +1,13 @@
+from unittest.case import TestCase
+
+from rrpproxy.utils.rrp_proxy_internal_status_exception import RRPProxyInternalStatusException
+
+
+class TestRRPProxyInteralStatusException(TestCase):
+    def test_inherits_from_exception(self):
+        self.assertIsInstance(RRPProxyInternalStatusException(code=400), Exception)
+
+    def test_sets_passed_in_code(self):
+        exception = RRPProxyInternalStatusException(code=400)
+
+        self.assertEqual(exception.code, 400)


### PR DESCRIPTION
Add RRPProxyInternalStatusException: To indicate that the rrp proxy request was successful, but rrp returned a status code indicating something was wrong.


Raise RRPProxyInternalStatusException if code >=400: If rrp handles the request successfully, but still returns an internal
error (i.e. nameserver invalid or something), make sure we raise an error so the calling party can handle this easier. Also supply the code in the exception so the calling party can make the correct action accordingly