### PR TITLE
Add response to internal status exception

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -39,7 +39,7 @@ class RRPProxy:
             if response_dict['code'] >= 400:
                 raise RRPProxyInternalStatusException(
                     "Request was successfully handled, but RRP returned internal status code '{}'. Please investigate "
-                    "and handle accordingly.".format(response_dict['code']), code=response_dict['code'])
+                    "and handle accordingly.".format(response_dict['code']), response_dict=response_dict)
             return response_dict
         except requests.ConnectionError:
             raise RRPProxyAPIDownException

--- a/rrpproxy/utils/rrp_proxy_internal_status_exception.py
+++ b/rrpproxy/utils/rrp_proxy_internal_status_exception.py
@@ -1,4 +1,4 @@
 class RRPProxyInternalStatusException(Exception):
     def __init__(self, *args, **kwargs):
-        self.code = kwargs.pop('code')
+        self.response_dict = kwargs.pop('response_dict')
         super(RRPProxyInternalStatusException, self).__init__(args, kwargs)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='rrpproxy',
-    version='0.1.0',
+    version='0.1.1',
     packages=find_packages(),
     include_package_data=True,
     description='A python connector for RRP Proxy',

--- a/tests/test_rrproxy_call.py
+++ b/tests/test_rrproxy_call.py
@@ -55,7 +55,7 @@ class TestRRPProxyCall(TestRRPProxyBase):
         with self.assertRaises(RRPProxyInternalStatusException) as cm:
             self.proxy.call('CheckDomain', domain='hypernode.com')
 
-        self.assertEqual(cm.exception.code, 400)
+        self.assertCountEqual(cm.exception.response_dict, {'code': 400})
 
     def test_raises_rrp_proxy_internal_status_exception_if_code_is_higher_than_400(self):
         self.get_mock.return_value = MagicMock(text='[RESPONSE]\ncode = 401\nEOF\n')
@@ -63,7 +63,7 @@ class TestRRPProxyCall(TestRRPProxyBase):
         with self.assertRaises(RRPProxyInternalStatusException) as cm:
             self.proxy.call('CheckDomain', domain='hypernode.com')
 
-        self.assertEqual(cm.exception.code, 401)
+        self.assertCountEqual(cm.exception.response_dict, {'code': 401})
 
     def test_does_not_raise_rrp_proxy_internal_status_exception_if_code_is_lower_than_400(self):
         self.get_mock.return_value = MagicMock(text='[RESPONSE]\ncode = 399\nEOF\n')

--- a/tests/utils/test_rrp_proxy_internal_status_exception.py
+++ b/tests/utils/test_rrp_proxy_internal_status_exception.py
@@ -5,9 +5,9 @@ from rrpproxy.utils.rrp_proxy_internal_status_exception import RRPProxyInternalS
 
 class TestRRPProxyInteralStatusException(TestCase):
     def test_inherits_from_exception(self):
-        self.assertIsInstance(RRPProxyInternalStatusException(code=400), Exception)
+        self.assertIsInstance(RRPProxyInternalStatusException(response_dict={}), Exception)
 
     def test_sets_passed_in_code(self):
-        exception = RRPProxyInternalStatusException(code=400)
+        exception = RRPProxyInternalStatusException(response_dict={'my': 'custom', 'response': 'dict'})
 
-        self.assertEqual(exception.code, 400)
+        self.assertCountEqual(exception.response_dict, {'my': 'custom', 'response': 'dict'})


### PR DESCRIPTION
Add entire response dict to internal status exception: Instead of only passing the status code to the internal status exception, which does not give that much info in itself, we can and should just pass in the entire response dict. This will container more info the calling party can use the handle the error.

