### PR TITLE
Add query calls for Domains and Domain Transfers

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -146,6 +146,14 @@ class RRPProxy:
         """Query list of domains in account."""
         return self.call('QueryDomainList', **query_domain_data)
 
+    def query_transfer_list(self, **query_transfer_data):
+        """Query a list of incoming (running) domain transfers from an external registrar"""
+        return self.call('QueryTransferList', **query_transfer_data)
+
+    def query_foreign_transfer_list(self, **query_transfer_data):
+        """Query a list of all domain which are currently in a transfer-out process"""
+        return self.call('QueryForeignTransferList', **query_transfer_data)
+
     def query_zone_list(self):
         """Query list of activated zones in account"""
         return self.call('QueryZoneList')

--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import requests
+import time
 
 from rrpproxy.utils.rrp_proxy_internal_status_exception import RRPProxyInternalStatusException
 from rrpproxy.utils.rrpproxy_api_down_exception import RRPProxyAPIDownException
@@ -157,3 +158,16 @@ class RRPProxy:
     def query_zone_list(self):
         """Query list of activated zones in account"""
         return self.call('QueryZoneList')
+
+    def get_domain_list_from_account(self, index=0, time_between_calls_in_seconds=1):
+        """Returns list of domains registered in your account"""
+        domain_list = self.query_domain_list(first=index)
+        next_index = domain_list['property']['last'][0] + 1
+        if domain_list['property']['total'][0] < next_index:
+            return domain_list['property']['domain'] if 'domain' in domain_list['property'] else []
+        else:
+            # According to RRPProxy (https://wiki.rrpproxy.net/api/epp-server/frequently-asked-questions )
+            # there is a rate limit of 1 command per second, therefore I added time.sleep as a parameter so
+            # we can add any custom delay between calls case we want to
+            time.sleep(time_between_calls_in_seconds)
+            return domain_list['property']['domain'] + self.get_domain_list_from_account(index=next_index)

--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -142,6 +142,10 @@ class RRPProxy:
         """This command allows you to request, approve, deny or cancel a domain transfer."""
         return self.call('TransferDomain', domain=domain, action=action, **transfer_data)
 
+    def query_domain_list(self, **query_domain_data):
+        """Query list of domains in account."""
+        return self.call('QueryDomainList', **query_domain_data)
+
     def query_zone_list(self):
         """Query list of activated zones in account"""
         return self.call('QueryZoneList')

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='rrpproxy',
-    version='0.1.2',
+    version='0.1.3',
     packages=find_packages(),
     include_package_data=True,
     description='A python connector for RRP Proxy',

--- a/tests/test_rrpproxy_get_domain_list_from_account.py
+++ b/tests/test_rrpproxy_get_domain_list_from_account.py
@@ -1,0 +1,106 @@
+from unittest.mock import Mock
+
+from tests.test_rrpproxy_base import TestRRPProxyBase
+
+
+class TestGetDomainListFromAccount(TestRRPProxyBase):
+    def setUp(self):
+        super().setUp()
+
+        self.time_sleep_mock = self.set_up_patch('rrpproxy.rrpproxy.time.sleep')
+        self.proxy.query_domain_list = Mock()
+        self.proxy.query_domain_list.return_value = {'property': {
+                'last': [2],
+                'total': [2],
+                'domain': ['domain1.nl', 'domain2.nl']
+        }}
+
+    def test_calls_query_domain_list_correctly(self):
+        index = 3
+        self.proxy.get_domain_list_from_account(index=index)
+
+        self.proxy.query_domain_list.assert_called_once_with(first=index)
+
+    def test_returns_domain_list_when_there_are_no_more_items_on_the_next_page(self):
+        ret = self.proxy.get_domain_list_from_account()
+
+        self.assertEqual(ret, self.proxy.query_domain_list.return_value['property']['domain'])
+
+    def test_returns_empty_array_when_there_are_no_more_items_on_the_next_page_and_domain_list_is_absent(self):
+        self.proxy.query_domain_list.return_value = {
+            'property': {
+                'last': [201],
+                'total': [200],
+            }
+        }
+
+        ret = self.proxy.get_domain_list_from_account()
+
+        self.assertEqual(ret, [])
+
+    def test_calls_sleep_when_there_are_more_domains_on_the_next_call(self):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': [2],
+                    'total': [4],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': [4],
+                    'total': [4],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_domain_list_from_account()
+
+        self.time_sleep_mock.assert_called_once_with(1)
+
+    def test_calls_sleep_with_correct_amount_of_seconds_if_time_between_calls_is_specified(self):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': [2],
+                    'total': [4],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': [4],
+                    'total': [4],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_domain_list_from_account(time_between_calls_in_seconds=5)
+
+        self.time_sleep_mock.assert_called_once_with(5)
+
+    def test_returns_domain_list_and_a_recursive_call_with_another_index_when_there_are_more_domains_on_the_next_page(
+            self):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': [2],
+                    'total': [4],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': [4],
+                    'total': [4],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        ret = self.proxy.get_domain_list_from_account()
+
+        self.assertEqual(ret, ['domain1.nl', 'domain2.nl', 'domain3.nl', 'domain4.nl'])

--- a/tests/test_rrpproxy_query_domain_list.py
+++ b/tests/test_rrpproxy_query_domain_list.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from tests.test_rrpproxy_base import TestRRPProxyBase
+
+
+class TestRRPProxyQueryDomainList(TestRRPProxyBase):
+    @patch('rrpproxy.RRPProxy.call')
+    def test_calls_call_correctly(self, call_mock):
+        response = self.proxy.query_domain_list()
+
+        call_mock.assert_called_once_with('QueryDomainList')
+        self.assertEqual(response, call_mock.return_value)
+
+    @patch('rrpproxy.RRPProxy.call')
+    def test_calls_call_with_kwargs_correctly(self, call_mock):
+        response = self.proxy.query_domain_list(domain='dogsarecool*')
+
+        call_mock.assert_called_once_with('QueryDomainList', domain='dogsarecool*')
+        self.assertEqual(response, call_mock.return_value)

--- a/tests/test_rrpproxy_query_foreign_transfer_list.py
+++ b/tests/test_rrpproxy_query_foreign_transfer_list.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from tests.test_rrpproxy_base import TestRRPProxyBase
+
+
+class TestRRPProxyQueryForeignTransferList(TestRRPProxyBase):
+    @patch('rrpproxy.RRPProxy.call')
+    def test_calls_call_correctly(self, call_mock):
+        response = self.proxy.query_foreign_transfer_list()
+
+        call_mock.assert_called_once_with('QueryForeignTransferList')
+        self.assertEqual(response, call_mock.return_value)
+
+    @patch('rrpproxy.RRPProxy.call')
+    def test_calls_call_with_kwargs_correctly(self, call_mock):
+        response = self.proxy.query_foreign_transfer_list(domain='dogsarecool*')
+
+        call_mock.assert_called_once_with('QueryForeignTransferList', domain='dogsarecool*')
+        self.assertEqual(response, call_mock.return_value)

--- a/tests/test_rrpproxy_query_transfer_list.py
+++ b/tests/test_rrpproxy_query_transfer_list.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from tests.test_rrpproxy_base import TestRRPProxyBase
+
+
+class TestRRPProxyQueryTransferList(TestRRPProxyBase):
+    @patch('rrpproxy.RRPProxy.call')
+    def test_calls_call_correctly(self, call_mock):
+        response = self.proxy.query_transfer_list()
+
+        call_mock.assert_called_once_with('QueryTransferList')
+        self.assertEqual(response, call_mock.return_value)
+
+    @patch('rrpproxy.RRPProxy.call')
+    def test_calls_call_with_kwargs_correctly(self, call_mock):
+        response = self.proxy.query_transfer_list(domain='dogsarecool*')
+
+        call_mock.assert_called_once_with('QueryTransferList', domain='dogsarecool*')
+        self.assertEqual(response, call_mock.return_value)


### PR DESCRIPTION
Added calls:
- [QueryDomainList](https://wiki.rrpproxy.net/api/api-command/QueryDomainList): Query list of domains in account
- [QueryTransferList](https://wiki.rrpproxy.net/api/api-command/QueryTransferList): Query a list of incoming (running) domain transfers from an external registrar
- [QueryForeignTransferList](https://wiki.rrpproxy.net/api/api-command/QueryForeignTransferList): Query a list of all domain which are currently in a transfer-out process