### PR TITLE
Add Get domain list from account

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import requests
+import time
 
 from rrpproxy.utils.rrp_proxy_internal_status_exception import RRPProxyInternalStatusException
 from rrpproxy.utils.rrpproxy_api_down_exception import RRPProxyAPIDownException
@@ -157,3 +158,13 @@ class RRPProxy:
     def query_zone_list(self):
         """Query list of activated zones in account"""
         return self.call('QueryZoneList')
+
+    def get_domain_list_from_account(self, index=0):
+        """Returns list of domains registered in your account"""
+        domain_list = self.query_domain_list(first=index)
+        next_index = domain_list['property']['last'][0] + 1
+        if domain_list['property']['total'][0] < next_index:
+            return domain_list['property']['domain'] if 'domain' in domain_list['property'] else []
+        else:
+            time.sleep(1)
+            return domain_list['property']['domain'] + self.get_domain_list_from_account(index=next_index)

--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -159,12 +159,15 @@ class RRPProxy:
         """Query list of activated zones in account"""
         return self.call('QueryZoneList')
 
-    def get_domain_list_from_account(self, index=0):
+    def get_domain_list_from_account(self, index=0, time_between_calls_in_seconds=1):
         """Returns list of domains registered in your account"""
         domain_list = self.query_domain_list(first=index)
         next_index = domain_list['property']['last'][0] + 1
         if domain_list['property']['total'][0] < next_index:
             return domain_list['property']['domain'] if 'domain' in domain_list['property'] else []
         else:
-            time.sleep(1)
+            # According to RRPProxy (https://wiki.rrpproxy.net/api/epp-server/frequently-asked-questions )
+            # there is a rate limit of 1 command per second, therefore I added time.sleep as a parameter so
+            # we can add any custom delay between calls case we want to
+            time.sleep(time_between_calls_in_seconds)
             return domain_list['property']['domain'] + self.get_domain_list_from_account(index=next_index)

--- a/tests/test_rrpproxy_get_domain_list_from_account.py
+++ b/tests/test_rrpproxy_get_domain_list_from_account.py
@@ -1,0 +1,84 @@
+from unittest.mock import Mock
+
+from tests.test_rrpproxy_base import TestRRPProxyBase
+
+
+class TestGetDomainListFromAccount(TestRRPProxyBase):
+    def setUp(self):
+        super().setUp()
+
+        self.time_sleep_mock = self.set_up_patch('rrpproxy.rrpproxy.time.sleep')
+        self.proxy.query_domain_list = Mock()
+        self.proxy.query_domain_list.return_value = {'property': {
+                'last': [2],
+                'total': [2],
+                'domain': ['domain1.nl', 'domain2.nl']
+        }}
+
+    def test_calls_query_domain_list_correctly(self):
+        index = 3
+        self.proxy.get_domain_list_from_account(index=index)
+
+        self.proxy.query_domain_list.assert_called_once_with(first=index)
+
+    def test_returns_domain_list_when_there_are_no_more_items_on_the_next_page(self):
+        ret = self.proxy.get_domain_list_from_account()
+
+        self.assertEqual(ret, self.proxy.query_domain_list.return_value['property']['domain'])
+
+    def test_returns_empty_array_when_there_are_no_more_items_on_the_next_page_and_domain_list_is_absent(self):
+        self.proxy.query_domain_list.return_value = {
+            'property': {
+                'last': [201],
+                'total': [200],
+            }
+        }
+
+        ret = self.proxy.get_domain_list_from_account()
+
+        self.assertEqual(ret, [])
+
+    def test_calls_sleep_when_there_are_more_domains_on_the_next_call(self):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': [2],
+                    'total': [4],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': [4],
+                    'total': [4],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_domain_list_from_account()
+
+        self.time_sleep_mock.assert_called_once_with(1)
+
+    def test_returns_domain_list_and_a_recursive_call_with_another_index_when_there_are_more_domains_on_the_next_page(
+            self):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': [2],
+                    'total': [4],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': [4],
+                    'total': [4],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        ret = self.proxy.get_domain_list_from_account()
+
+        self.assertEqual(ret, ['domain1.nl', 'domain2.nl', 'domain3.nl', 'domain4.nl'])

--- a/tests/test_rrpproxy_get_domain_list_from_account.py
+++ b/tests/test_rrpproxy_get_domain_list_from_account.py
@@ -60,6 +60,28 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
 
         self.time_sleep_mock.assert_called_once_with(1)
 
+    def test_calls_sleep_with_correct_amount_of_seconds_if_time_between_calls_is_specified(self):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': [2],
+                    'total': [4],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': [4],
+                    'total': [4],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_domain_list_from_account(time_between_calls_in_seconds=5)
+
+        self.time_sleep_mock.assert_called_once_with(5)
+
     def test_returns_domain_list_and_a_recursive_call_with_another_index_when_there_are_more_domains_on_the_next_page(
             self):
         self.proxy.query_domain_list.side_effect = [


### PR DESCRIPTION
`query_domain_list` is kind of limiting since it is paginated, So I added this recursive function so we can get all domain names in one list. 

Note:[ I also added a time.sleep(1) since RRPProxy has a rate limit of 1 call per second ](https://wiki.rrpproxy.net/api/epp-server/frequently-asked-questions)