### PR TITLE
Cast last and total to int

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -162,8 +162,9 @@ class RRPProxy:
     def get_domain_list_from_account(self, index=0, time_between_calls_in_seconds=1):
         """Returns list of domains registered in your account"""
         domain_list = self.query_domain_list(first=index)
-        next_index = domain_list['property']['last'][0] + 1
-        if domain_list['property']['total'][0] < next_index:
+        next_index = int(domain_list['property']['last'][0]) + 1
+        total_domains = int(domain_list['property']['total'][0])
+        if total_domains < next_index:
             return domain_list['property']['domain'] if 'domain' in domain_list['property'] else []
         else:
             # According to RRPProxy (https://wiki.rrpproxy.net/api/epp-server/frequently-asked-questions )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='rrpproxy',
-    version='0.1.3',
+    version='0.1.4',
     packages=find_packages(),
     include_package_data=True,
     description='A python connector for RRP Proxy',

--- a/tests/test_rrpproxy_get_domain_list_from_account.py
+++ b/tests/test_rrpproxy_get_domain_list_from_account.py
@@ -10,8 +10,8 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
         self.time_sleep_mock = self.set_up_patch('rrpproxy.rrpproxy.time.sleep')
         self.proxy.query_domain_list = Mock()
         self.proxy.query_domain_list.return_value = {'property': {
-                'last': [2],
-                'total': [2],
+                'last': ['2'],
+                'total': ['2'],
                 'domain': ['domain1.nl', 'domain2.nl']
         }}
 
@@ -29,8 +29,8 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
     def test_returns_empty_array_when_there_are_no_more_items_on_the_next_page_and_domain_list_is_absent(self):
         self.proxy.query_domain_list.return_value = {
             'property': {
-                'last': [201],
-                'total': [200],
+                'last': ['201'],
+                'total': ['200'],
             }
         }
 
@@ -42,16 +42,16 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
         self.proxy.query_domain_list.side_effect = [
             {
                 'property': {
-                    'last': [2],
-                    'total': [4],
+                    'last': ['2'],
+                    'total': ['4'],
                     'domain': ['domain1.nl', 'domain2.nl']
                 }
             },
             {
                 'property': {
-                    'last': [4],
-                    'total': [4],
-                    'domain': ['domain3.nl', 'domain4.nl']
+                    'last': ['4'],
+                    'total': ['4'],
+                    'domain': ['domZain3.nl', 'domain4.nl']
                 }
             }
         ]
@@ -64,15 +64,15 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
         self.proxy.query_domain_list.side_effect = [
             {
                 'property': {
-                    'last': [2],
-                    'total': [4],
+                    'last': ['2'],
+                    'total': ['4'],
                     'domain': ['domain1.nl', 'domain2.nl']
                 }
             },
             {
                 'property': {
-                    'last': [4],
-                    'total': [4],
+                    'last': ['4'],
+                    'total': ['4'],
                     'domain': ['domain3.nl', 'domain4.nl']
                 }
             }
@@ -87,15 +87,15 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
         self.proxy.query_domain_list.side_effect = [
             {
                 'property': {
-                    'last': [2],
-                    'total': [4],
+                    'last': ['2'],
+                    'total': ['4'],
                     'domain': ['domain1.nl', 'domain2.nl']
                 }
             },
             {
                 'property': {
-                    'last': [4],
-                    'total': [4],
+                    'last': ['4'],
+                    'total': ['4'],
                     'domain': ['domain3.nl', 'domain4.nl']
                 }
             }


### PR DESCRIPTION
RRPProxy last and total input is in string, not an integer. 
Cast it to int so it doesn't fail with arithmetic operations or comparison