### PR TITLE
Get last updated domains with details

### DIFF
--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -175,7 +175,7 @@ class RRPProxy:
         :param int index: Start results from this item
         :param bool retrieve_all: Setting this to true will return all domains in the account, otherwise
         this function will return the last 1000 updated domains
-        :param int time_between_calls_in_seconds: Custom delay in seconds between calls
+        :param int time_between_calls_in_seconds: Custom delay in seconds between API calls
         """
         domain_list = self.query_domain_list(first=index, type='ALL', orderby='DOMAINUPDATEDDATE', order='DESC',
                                              **kwargs)

--- a/rrpproxy/rrpproxy.py
+++ b/rrpproxy/rrpproxy.py
@@ -164,7 +164,7 @@ class RRPProxy:
         """Returns list of domains registered in your account"""
         domain_list = self.get_last_updated_domains_with_details(retrieve_all=True, **kwargs)
 
-        return [domain['name'] for domain in domain_list]
+        return [domain['domain'] for domain in domain_list]
 
     def get_last_updated_domains_with_details(self, index=0, retrieve_all=False, time_between_calls_in_seconds=1,
                                               **kwargs):

--- a/rrpproxy/utils/populate_domain_list.py
+++ b/rrpproxy/utils/populate_domain_list.py
@@ -1,5 +1,15 @@
 
 def populate_domain_list(domains_in_rrpproxy_format):
+    """
+    This method takes the default format of RRP domains
+    (a dictionary of lists for each property) and converts it
+    to a list of dictionaries. Each dict in the list represents
+    a domain and has the various properties as keys.
+    A property will be absent in the dict if it has it had no value.
+    :param dict domains_in_rrpproxy_format: Dict of lists with domain properties
+    :return: List of domain dictionaries
+    :rtype: list
+    """
     domain_list = []
     properties = domains_in_rrpproxy_format['property']
     for index in range(len(properties['domain'])):

--- a/rrpproxy/utils/populate_domain_list.py
+++ b/rrpproxy/utils/populate_domain_list.py
@@ -1,23 +1,24 @@
 
 def populate_domain_list(domains_in_rrpproxy_format):
     domain_list = []
-    for key, domain in enumerate(domains_in_rrpproxy_format['property']['domain']):
+    properties = domains_in_rrpproxy_format['property']
+    for index in range(len(properties['domain'])):
         domain_with_details = {
-            'name': domains_in_rrpproxy_format['property']['domain'][key],
-            'status': domains_in_rrpproxy_format['property']['domain status'][key],
-            'updated_date': domains_in_rrpproxy_format['property']['domain updated date'][key],
+            'name': properties['domain'][index],
+            'status': properties['domain status'][index],
+            'updated_date': properties['domain updated date'][index],
         }
 
-        if domains_in_rrpproxy_format['property']['nameserver'][key]:
-            domain_with_details['nameserver'] = domains_in_rrpproxy_format['property']['nameserver'][key]
-        if domains_in_rrpproxy_format['property']['admincontact'][key]:
-            domain_with_details['admin_contact'] = domains_in_rrpproxy_format['property']['admincontact'][key]
-        if domains_in_rrpproxy_format['property']['techcontact'][key]:
-            domain_with_details['tech_contact'] = domains_in_rrpproxy_format['property']['techcontact'][key]
-        if domains_in_rrpproxy_format['property']['billingcontact'][key]:
-            domain_with_details['billing_contact'] = domains_in_rrpproxy_format['property']['billingcontact'][key]
-        if domains_in_rrpproxy_format['property']['ownercontact'][key]:
-            domain_with_details['owner_contact'] = domains_in_rrpproxy_format['property']['ownercontact'][key]
+        if properties['nameserver'][index]:
+            domain_with_details['nameserver'] = properties['nameserver'][index]
+        if properties['admincontact'][index]:
+            domain_with_details['admin_contact'] = properties['admincontact'][index]
+        if properties['techcontact'][index]:
+            domain_with_details['tech_contact'] = properties['techcontact'][index]
+        if properties['billingcontact'][index]:
+            domain_with_details['billing_contact'] = properties['billingcontact'][index]
+        if properties['ownercontact'][index]:
+            domain_with_details['owner_contact'] = properties['ownercontact'][index]
 
         domain_list.append(domain_with_details)
 

--- a/rrpproxy/utils/populate_domain_list.py
+++ b/rrpproxy/utils/populate_domain_list.py
@@ -1,0 +1,15 @@
+
+def populate_domain_list(domains_in_rrpproxy_format):
+    domain_list = []
+    for key, domain in enumerate(domains_in_rrpproxy_format['property']['domain']):
+        domain_list.append({
+            'name': domains_in_rrpproxy_format['property']['domain'][key],
+            'status': domains_in_rrpproxy_format['property']['domain status'][key],
+            'updated_date': domains_in_rrpproxy_format['property']['domain updated date'][key],
+            'nameserver': domains_in_rrpproxy_format['property']['nameserver'][key],
+            'admin_contact': domains_in_rrpproxy_format['property']['admincontact'][key],
+            'tech_contact': domains_in_rrpproxy_format['property']['techcontact'][key],
+            'billing_contact': domains_in_rrpproxy_format['property']['billingcontact'][key],
+            'owner_contact': domains_in_rrpproxy_format['property']['ownercontact'][key],
+        })
+    return domain_list

--- a/rrpproxy/utils/populate_domain_list.py
+++ b/rrpproxy/utils/populate_domain_list.py
@@ -2,14 +2,23 @@
 def populate_domain_list(domains_in_rrpproxy_format):
     domain_list = []
     for key, domain in enumerate(domains_in_rrpproxy_format['property']['domain']):
-        domain_list.append({
+        domain_with_details = {
             'name': domains_in_rrpproxy_format['property']['domain'][key],
             'status': domains_in_rrpproxy_format['property']['domain status'][key],
             'updated_date': domains_in_rrpproxy_format['property']['domain updated date'][key],
-            'nameserver': domains_in_rrpproxy_format['property']['nameserver'][key],
-            'admin_contact': domains_in_rrpproxy_format['property']['admincontact'][key],
-            'tech_contact': domains_in_rrpproxy_format['property']['techcontact'][key],
-            'billing_contact': domains_in_rrpproxy_format['property']['billingcontact'][key],
-            'owner_contact': domains_in_rrpproxy_format['property']['ownercontact'][key],
-        })
+        }
+
+        if domains_in_rrpproxy_format['property']['nameserver'][key]:
+            domain_with_details['nameserver'] = domains_in_rrpproxy_format['property']['nameserver'][key]
+        if domains_in_rrpproxy_format['property']['admincontact'][key]:
+            domain_with_details['admin_contact'] = domains_in_rrpproxy_format['property']['admincontact'][key]
+        if domains_in_rrpproxy_format['property']['techcontact'][key]:
+            domain_with_details['tech_contact'] = domains_in_rrpproxy_format['property']['techcontact'][key]
+        if domains_in_rrpproxy_format['property']['billingcontact'][key]:
+            domain_with_details['billing_contact'] = domains_in_rrpproxy_format['property']['billingcontact'][key]
+        if domains_in_rrpproxy_format['property']['ownercontact'][key]:
+            domain_with_details['owner_contact'] = domains_in_rrpproxy_format['property']['ownercontact'][key]
+
+        domain_list.append(domain_with_details)
+
     return domain_list

--- a/rrpproxy/utils/populate_domain_list.py
+++ b/rrpproxy/utils/populate_domain_list.py
@@ -1,4 +1,8 @@
 
+RRPPROXY_DOMAIN_FIELDS = ('domain', 'domain status', 'domain updated date', 'nameserver', 'admincontact',
+                          'techcontact', 'billingcontact', 'ownercontact')
+
+
 def populate_domain_list(domains_in_rrpproxy_format):
     """
     This method takes the default format of RRP domains
@@ -13,22 +17,10 @@ def populate_domain_list(domains_in_rrpproxy_format):
     domain_list = []
     properties = domains_in_rrpproxy_format['property']
     for index in range(len(properties['domain'])):
-        domain_with_details = {
-            'name': properties['domain'][index],
-            'status': properties['domain status'][index],
-            'updated_date': properties['domain updated date'][index],
-        }
-
-        if properties['nameserver'][index]:
-            domain_with_details['nameserver'] = properties['nameserver'][index]
-        if properties['admincontact'][index]:
-            domain_with_details['admin_contact'] = properties['admincontact'][index]
-        if properties['techcontact'][index]:
-            domain_with_details['tech_contact'] = properties['techcontact'][index]
-        if properties['billingcontact'][index]:
-            domain_with_details['billing_contact'] = properties['billingcontact'][index]
-        if properties['ownercontact'][index]:
-            domain_with_details['owner_contact'] = properties['ownercontact'][index]
+        domain_with_details = {}
+        for domain_field in RRPPROXY_DOMAIN_FIELDS:
+            if properties[domain_field][index]:
+                domain_with_details[domain_field] = properties[domain_field][index]
 
         domain_list.append(domain_with_details)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='rrpproxy',
-    version='0.1.4',
+    version='0.1.5',
     packages=find_packages(),
     include_package_data=True,
     description='A python connector for RRP Proxy',

--- a/tests/test_get_last_updated_domains_with_details.py
+++ b/tests/test_get_last_updated_domains_with_details.py
@@ -20,6 +20,12 @@ class TestGetLastUpdatedDomainsWithDetails(TestRRPProxyBase):
         self.proxy.query_domain_list.assert_called_once_with(first=index, type='ALL', orderby='DOMAINUPDATEDDATE',
                                                              order='DESC')
 
+    def test_calls_query_domain_list_correctly_with_kwargs(self):
+        self.proxy.get_last_updated_domains_with_details(one_keyword='one_value')
+
+        self.proxy.query_domain_list.assert_called_once_with(first=0, type='ALL', orderby='DOMAINUPDATEDDATE',
+                                                             order='DESC', one_keyword='one_value')
+
     @patch('rrpproxy.rrpproxy.populate_domain_list')
     def test_calls_query_domain_list_once_if_retrieve_all_is_set_to_false(self, _):
         self.proxy.query_domain_list.side_effect = [
@@ -34,7 +40,7 @@ class TestGetLastUpdatedDomainsWithDetails(TestRRPProxyBase):
                 'property': {
                     'last': ['4'],
                     'total': ['4'],
-                    'domain': ['domZain3.nl', 'domain4.nl']
+                    'domain': ['domain3.nl', 'domain4.nl']
                 }
             }
         ]
@@ -57,7 +63,7 @@ class TestGetLastUpdatedDomainsWithDetails(TestRRPProxyBase):
                 'property': {
                     'last': ['4'],
                     'total': ['4'],
-                    'domain': ['domZain3.nl', 'domain4.nl']
+                    'domain': ['domain3.nl', 'domain4.nl']
                 }
             }
         ]
@@ -100,7 +106,7 @@ class TestGetLastUpdatedDomainsWithDetails(TestRRPProxyBase):
                 'property': {
                     'last': ['4'],
                     'total': ['4'],
-                    'domain': ['domZain3.nl', 'domain4.nl']
+                    'domain': ['domain3.nl', 'domain4.nl']
                 }
             }
         ]

--- a/tests/test_get_last_updated_domains_with_details.py
+++ b/tests/test_get_last_updated_domains_with_details.py
@@ -1,0 +1,169 @@
+from unittest.mock import Mock, patch, call
+
+from rrpproxy.utils.populate_domain_list import populate_domain_list
+from tests.test_rrpproxy_base import TestRRPProxyBase
+
+
+class TestGetLastUpdatedDomainsWithDetails(TestRRPProxyBase):
+    def setUp(self):
+        super().setUp()
+
+        self.time_sleep_mock = self.set_up_patch('rrpproxy.rrpproxy.time.sleep')
+        self.proxy.query_domain_list = Mock()
+        self.proxy.query_domain_list.return_value = self.sample_query_domain_list
+
+    def test_calls_query_domain_list_correctly(self):
+        index = 3
+
+        self.proxy.get_last_updated_domains_with_details(index=index)
+
+        self.proxy.query_domain_list.assert_called_once_with(first=index, type='ALL', orderby='DOMAINUPDATEDDATE',
+                                                             order='DESC')
+
+    @patch('rrpproxy.rrpproxy.populate_domain_list')
+    def test_calls_query_domain_list_once_if_retrieve_all_is_set_to_false(self, _):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': ['2'],
+                    'total': ['4'],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': ['4'],
+                    'total': ['4'],
+                    'domain': ['domZain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_last_updated_domains_with_details(retrieve_all=False)
+
+        self.proxy.query_domain_list.assert_called_once_with(first=0, type='ALL', orderby='DOMAINUPDATEDDATE', order='DESC')
+
+    @patch('rrpproxy.rrpproxy.populate_domain_list')
+    def test_calls_query_domain_list_n_times_if_retrieve_all_is_true_and_there_are_more_domains_in_next_page(self, _):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': ['2'],
+                    'total': ['4'],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': ['4'],
+                    'total': ['4'],
+                    'domain': ['domZain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_last_updated_domains_with_details(retrieve_all=True)
+
+        self.proxy.query_domain_list.assert_has_calls([
+            call(first=0, type='ALL', orderby='DOMAINUPDATEDDATE', order='DESC'),
+            call(first=3, type='ALL', orderby='DOMAINUPDATEDDATE', order='DESC')
+        ])
+
+    def test_returns_domain_list_when_retrieve_all_is_true_but_there_are_no_more_items_on_the_next_page(self):
+        ret = self.proxy.get_last_updated_domains_with_details(retrieve_all=True)
+
+        self.assertEqual(ret, populate_domain_list(self.proxy.query_domain_list.return_value))
+
+    def test_returns_empty_array_when_there_are_no_more_items_on_the_next_page_and_domain_list_is_absent(self):
+        self.proxy.query_domain_list.return_value = {
+            'property': {
+                'last': ['201'],
+                'total': ['200']
+            }
+        }
+
+        ret = self.proxy.get_last_updated_domains_with_details()
+
+        self.assertEqual(ret, [])
+
+    @patch('rrpproxy.rrpproxy.populate_domain_list')
+    def test_calls_sleep_when_there_are_more_domains_on_the_next_call_and_retrieve_all_is_true(self, _):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': ['2'],
+                    'total': ['4'],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': ['4'],
+                    'total': ['4'],
+                    'domain': ['domZain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_last_updated_domains_with_details(retrieve_all=True)
+
+        self.time_sleep_mock.assert_called_once_with(1)
+
+    @patch('rrpproxy.rrpproxy.populate_domain_list')
+    def test_calls_sleep_with_correct_amount_of_seconds_if_time_between_calls_is_specified(self, _):
+        self.proxy.query_domain_list.side_effect = [
+            {
+                'property': {
+                    'last': ['2'],
+                    'total': ['4'],
+                    'domain': ['domain1.nl', 'domain2.nl']
+                }
+            },
+            {
+                'property': {
+                    'last': ['4'],
+                    'total': ['4'],
+                    'domain': ['domain3.nl', 'domain4.nl']
+                }
+            }
+        ]
+
+        self.proxy.get_last_updated_domains_with_details(retrieve_all=True, time_between_calls_in_seconds=5)
+
+        self.time_sleep_mock.assert_called_once_with(5)
+
+    def test_returns_domain_list_and_a_recursive_call_with_another_index_when_there_are_more_domains_on_the_next_page(
+            self):
+        first_response = {
+            'property': {
+                'last': ['2'],
+                'total': ['4'],
+                'domain': ['domain1.nl', 'domain2.nl'],
+                'domain status': ['ACTIVE', 'ACTIVE'],
+                'domain updated date': ['2021-01-21', '2021-01-21'],
+                'nameserver': ['ns1;ns2;ns3', 'ns1;ns2;ns3'],
+                'admincontact': ['CNT-123', 'CNT-456'],
+                'techcontact': ['CNT-123', 'CNT-456'],
+                'billingcontact': ['CNT-123', 'CNT-456'],
+                'ownercontact': ['CNT-123', 'CNT-456'],
+            }
+        }
+        second_response = {
+            'property': {
+                'last': ['4'],
+                'total': ['4'],
+                'domain': ['domain3.nl', 'domain4.nl'],
+                'domain status': ['ACTIVE', 'ACTIVE'],
+                'domain updated date': ['2021-01-21', '2021-01-21'],
+                'nameserver': ['ns1;ns2;ns3', 'ns1;ns2;ns3'],
+                'admincontact': ['CNT-123', 'CNT-456'],
+                'techcontact': ['CNT-123', 'CNT-456'],
+                'billingcontact': ['CNT-123', 'CNT-456'],
+                'ownercontact': ['CNT-123', 'CNT-456'],
+            }
+        }
+        self.proxy.query_domain_list.side_effect = [first_response, second_response]
+
+        ret = self.proxy.get_last_updated_domains_with_details(retrieve_all=True)
+
+        self.assertEqual(ret, populate_domain_list(first_response) + populate_domain_list(second_response))

--- a/tests/test_rrpproxy_base.py
+++ b/tests/test_rrpproxy_base.py
@@ -10,6 +10,20 @@ class TestRRPProxyBase(TestCase):
         self.username = 'dummy_username'
         self.password = 'secret_password'
         self.proxy = RRPProxy(self.username, self.password, use_test_environment=True)
+        self.sample_query_domain_list = {
+            'property': {
+                'last': ['2'],
+                'total': ['2'],
+                'domain': ['domain1.nl', 'domain2.nl'],
+                'domain status': ['ACTIVE', 'ACTIVE'],
+                'domain updated date': ['2021-01-21', '2021-01-21'],
+                'nameserver': ['ns1;ns2;ns3', 'ns1;ns2;ns3'],
+                'admincontact': ['CNT-123', 'CNT-456'],
+                'techcontact': ['CNT-123', 'CNT-456'],
+                'billingcontact': ['CNT-123', 'CNT-456'],
+                'ownercontact': ['CNT-123', 'CNT-456'],
+            }
+        }
 
     def set_up_patch(self, name, *args, **kwargs):
         patch = mock.patch(name, *args, **kwargs)

--- a/tests/test_rrpproxy_get_domain_list_from_account.py
+++ b/tests/test_rrpproxy_get_domain_list_from_account.py
@@ -9,98 +9,18 @@ class TestGetDomainListFromAccount(TestRRPProxyBase):
 
         self.time_sleep_mock = self.set_up_patch('rrpproxy.rrpproxy.time.sleep')
         self.proxy.query_domain_list = Mock()
-        self.proxy.query_domain_list.return_value = {'property': {
-                'last': ['2'],
-                'total': ['2'],
-                'domain': ['domain1.nl', 'domain2.nl']
-        }}
+        self.proxy.query_domain_list.return_value = self.sample_query_domain_list
 
-    def test_calls_query_domain_list_correctly(self):
-        index = 3
-        self.proxy.get_domain_list_from_account(index=index)
+    def test_calls_get_domain_list_with_details_correctly(self):
+        self.proxy.get_last_updated_domains_with_details = Mock()
+        self.proxy.get_last_updated_domains_with_details.return_value = []
 
-        self.proxy.query_domain_list.assert_called_once_with(first=index)
+        self.proxy.get_domain_list_from_account(one_argument='one_value')
 
-    def test_returns_domain_list_when_there_are_no_more_items_on_the_next_page(self):
+        self.proxy.get_last_updated_domains_with_details.assert_called_once_with(retrieve_all=True,
+                                                                                 one_argument='one_value')
+
+    def test_returns_array_of_domains(self):
         ret = self.proxy.get_domain_list_from_account()
 
-        self.assertEqual(ret, self.proxy.query_domain_list.return_value['property']['domain'])
-
-    def test_returns_empty_array_when_there_are_no_more_items_on_the_next_page_and_domain_list_is_absent(self):
-        self.proxy.query_domain_list.return_value = {
-            'property': {
-                'last': ['201'],
-                'total': ['200'],
-            }
-        }
-
-        ret = self.proxy.get_domain_list_from_account()
-
-        self.assertEqual(ret, [])
-
-    def test_calls_sleep_when_there_are_more_domains_on_the_next_call(self):
-        self.proxy.query_domain_list.side_effect = [
-            {
-                'property': {
-                    'last': ['2'],
-                    'total': ['4'],
-                    'domain': ['domain1.nl', 'domain2.nl']
-                }
-            },
-            {
-                'property': {
-                    'last': ['4'],
-                    'total': ['4'],
-                    'domain': ['domZain3.nl', 'domain4.nl']
-                }
-            }
-        ]
-
-        self.proxy.get_domain_list_from_account()
-
-        self.time_sleep_mock.assert_called_once_with(1)
-
-    def test_calls_sleep_with_correct_amount_of_seconds_if_time_between_calls_is_specified(self):
-        self.proxy.query_domain_list.side_effect = [
-            {
-                'property': {
-                    'last': ['2'],
-                    'total': ['4'],
-                    'domain': ['domain1.nl', 'domain2.nl']
-                }
-            },
-            {
-                'property': {
-                    'last': ['4'],
-                    'total': ['4'],
-                    'domain': ['domain3.nl', 'domain4.nl']
-                }
-            }
-        ]
-
-        self.proxy.get_domain_list_from_account(time_between_calls_in_seconds=5)
-
-        self.time_sleep_mock.assert_called_once_with(5)
-
-    def test_returns_domain_list_and_a_recursive_call_with_another_index_when_there_are_more_domains_on_the_next_page(
-            self):
-        self.proxy.query_domain_list.side_effect = [
-            {
-                'property': {
-                    'last': ['2'],
-                    'total': ['4'],
-                    'domain': ['domain1.nl', 'domain2.nl']
-                }
-            },
-            {
-                'property': {
-                    'last': ['4'],
-                    'total': ['4'],
-                    'domain': ['domain3.nl', 'domain4.nl']
-                }
-            }
-        ]
-
-        ret = self.proxy.get_domain_list_from_account()
-
-        self.assertEqual(ret, ['domain1.nl', 'domain2.nl', 'domain3.nl', 'domain4.nl'])
+        self.assertEqual(ret, ['domain1.nl', 'domain2.nl'])

--- a/tests/utils/test_populate_domain_list.py
+++ b/tests/utils/test_populate_domain_list.py
@@ -1,6 +1,6 @@
 from unittest.case import TestCase
 
-from rrpproxy.utils.populate_domain_list import populate_domain_list
+from rrpproxy.utils.populate_domain_list import populate_domain_list, RRPPROXY_DOMAIN_FIELDS
 
 
 class TestPopulateDomainList(TestCase):
@@ -18,19 +18,24 @@ class TestPopulateDomainList(TestCase):
             }
         }
 
+    def test_rrpproxy_domain_fields_are_correct(self):
+        self.assertEqual(RRPPROXY_DOMAIN_FIELDS,
+                         ('domain', 'domain status', 'domain updated date', 'nameserver', 'admincontact', 'techcontact',
+                          'billingcontact', 'ownercontact'))
+
     def test_returns_data_in_the_correct_format(self):
         domain_list = populate_domain_list(self.rrpproxy_output_data)
 
         self.assertEqual(domain_list, [
-            {'name': 'domain1.nl', 'status': 'ACTIVE', 'updated_date': '2018-06-12 16:59:00',
-             'nameserver': 'dummy1;dummy;dummy', 'admin_contact': 'admin1', 'tech_contact': 'tech1',
-             'billing_contact': 'billing1', 'owner_contact': 'owner1'},
-            {'name': 'domain2.nl', 'status': 'INACTIVE', 'updated_date': '2018-06-12 16:40:00',
-             'nameserver': 'dummy2;dummy;dummy', 'admin_contact': 'admin2', 'tech_contact': 'tech2',
-             'billing_contact': 'billing2', 'owner_contact': 'owner2'},
-            {'name': 'domain3.nl', 'status': 'ACTIVE', 'updated_date': '2018-06-12 16:30:00',
-             'nameserver': 'dummy3;dummy;dummy', 'admin_contact': 'admin3', 'tech_contact': 'tech3',
-             'billing_contact': 'billing3', 'owner_contact': 'owner3'},
+            {'domain': 'domain1.nl', 'domain status': 'ACTIVE', 'domain updated date': '2018-06-12 16:59:00',
+             'nameserver': 'dummy1;dummy;dummy', 'admincontact': 'admin1', 'techcontact': 'tech1',
+             'billingcontact': 'billing1', 'ownercontact': 'owner1'},
+            {'domain': 'domain2.nl', 'domain status': 'INACTIVE', 'domain updated date': '2018-06-12 16:40:00',
+             'nameserver': 'dummy2;dummy;dummy', 'admincontact': 'admin2', 'techcontact': 'tech2',
+             'billingcontact': 'billing2', 'ownercontact': 'owner2'},
+            {'domain': 'domain3.nl', 'domain status': 'ACTIVE', 'domain updated date': '2018-06-12 16:30:00',
+             'nameserver': 'dummy3;dummy;dummy', 'admincontact': 'admin3', 'techcontact': 'tech3',
+             'billingcontact': 'billing3', 'ownercontact': 'owner3'},
         ])
 
     def test_returns_data_without_nameserver_if_empty(self):
@@ -45,25 +50,25 @@ class TestPopulateDomainList(TestCase):
 
         domain_list = populate_domain_list(self.rrpproxy_output_data)
 
-        self.assertNotIn('admin_contact', domain_list[0])
+        self.assertNotIn('admincontact', domain_list[0])
 
     def test_returns_data_without_tech_contact_if_empty(self):
         self.rrpproxy_output_data['property']['techcontact'][0] = ''
 
         domain_list = populate_domain_list(self.rrpproxy_output_data)
 
-        self.assertNotIn('tech_contact', domain_list[0])
+        self.assertNotIn('techcontact', domain_list[0])
 
     def test_returns_data_without_billing_contact_if_empty(self):
         self.rrpproxy_output_data['property']['billingcontact'][0] = ''
 
         domain_list = populate_domain_list(self.rrpproxy_output_data)
 
-        self.assertNotIn('billing_contact', domain_list[0])
+        self.assertNotIn('billingcontact', domain_list[0])
 
     def test_returns_data_without_owner_contact_if_empty(self):
         self.rrpproxy_output_data['property']['ownercontact'][0] = ''
 
         domain_list = populate_domain_list(self.rrpproxy_output_data)
 
-        self.assertNotIn('owner_contact', domain_list[0])
+        self.assertNotIn('ownercontact', domain_list[0])

--- a/tests/utils/test_populate_domain_list.py
+++ b/tests/utils/test_populate_domain_list.py
@@ -4,8 +4,8 @@ from rrpproxy.utils.populate_domain_list import populate_domain_list
 
 
 class TestPopulateDomainList(TestCase):
-    def test_returns_data_in_the_correct_format(self):
-        rrpproxy_output_data = {
+    def setUp(self):
+        self.rrpproxy_output_data = {
             'property': {
                 'domain': ['domain1.nl', 'domain2.nl', 'domain3.nl'],
                 'domain status': ['ACTIVE', 'INACTIVE', 'ACTIVE'],
@@ -18,9 +18,9 @@ class TestPopulateDomainList(TestCase):
             }
         }
 
-        domain_list = populate_domain_list(rrpproxy_output_data)
+    def test_returns_data_in_the_correct_format(self):
+        domain_list = populate_domain_list(self.rrpproxy_output_data)
 
-        self.assertEqual(len(domain_list), len(rrpproxy_output_data['property']['domain']))
         self.assertEqual(domain_list, [
             {'name': 'domain1.nl', 'status': 'ACTIVE', 'updated_date': '2018-06-12 16:59:00',
              'nameserver': 'dummy1;dummy;dummy', 'admin_contact': 'admin1', 'tech_contact': 'tech1',
@@ -32,3 +32,38 @@ class TestPopulateDomainList(TestCase):
              'nameserver': 'dummy3;dummy;dummy', 'admin_contact': 'admin3', 'tech_contact': 'tech3',
              'billing_contact': 'billing3', 'owner_contact': 'owner3'},
         ])
+
+    def test_returns_data_without_nameserver_if_empty(self):
+        self.rrpproxy_output_data['property']['nameserver'][0] = ''
+
+        domain_list = populate_domain_list(self.rrpproxy_output_data)
+
+        self.assertNotIn('nameserver', domain_list[0])
+
+    def test_returns_data_without_admin_contact_if_empty(self):
+        self.rrpproxy_output_data['property']['admincontact'][0] = ''
+
+        domain_list = populate_domain_list(self.rrpproxy_output_data)
+
+        self.assertNotIn('admin_contact', domain_list[0])
+
+    def test_returns_data_without_tech_contact_if_empty(self):
+        self.rrpproxy_output_data['property']['techcontact'][0] = ''
+
+        domain_list = populate_domain_list(self.rrpproxy_output_data)
+
+        self.assertNotIn('tech_contact', domain_list[0])
+
+    def test_returns_data_without_billing_contact_if_empty(self):
+        self.rrpproxy_output_data['property']['billingcontact'][0] = ''
+
+        domain_list = populate_domain_list(self.rrpproxy_output_data)
+
+        self.assertNotIn('billing_contact', domain_list[0])
+
+    def test_returns_data_without_owner_contact_if_empty(self):
+        self.rrpproxy_output_data['property']['ownercontact'][0] = ''
+
+        domain_list = populate_domain_list(self.rrpproxy_output_data)
+
+        self.assertNotIn('owner_contact', domain_list[0])

--- a/tests/utils/test_populate_domain_list.py
+++ b/tests/utils/test_populate_domain_list.py
@@ -1,0 +1,34 @@
+from unittest.case import TestCase
+
+from rrpproxy.utils.populate_domain_list import populate_domain_list
+
+
+class TestPopulateDomainList(TestCase):
+    def test_returns_data_in_the_correct_format(self):
+        rrpproxy_output_data = {
+            'property': {
+                'domain': ['domain1.nl', 'domain2.nl', 'domain3.nl'],
+                'domain status': ['ACTIVE', 'INACTIVE', 'ACTIVE'],
+                'domain updated date': ['2018-06-12 16:59:00', '2018-06-12 16:40:00', '2018-06-12 16:30:00'],
+                'nameserver': ['dummy1;dummy;dummy', 'dummy2;dummy;dummy', 'dummy3;dummy;dummy'],
+                'admincontact': ['admin1', 'admin2', 'admin3'],
+                'techcontact': ['tech1', 'tech2', 'tech3'],
+                'billingcontact': ['billing1', 'billing2', 'billing3'],
+                'ownercontact': ['owner1', 'owner2', 'owner3'],
+            }
+        }
+
+        domain_list = populate_domain_list(rrpproxy_output_data)
+
+        self.assertEqual(len(domain_list), len(rrpproxy_output_data['property']['domain']))
+        self.assertEqual(domain_list, [
+            {'name': 'domain1.nl', 'status': 'ACTIVE', 'updated_date': '2018-06-12 16:59:00',
+             'nameserver': 'dummy1;dummy;dummy', 'admin_contact': 'admin1', 'tech_contact': 'tech1',
+             'billing_contact': 'billing1', 'owner_contact': 'owner1'},
+            {'name': 'domain2.nl', 'status': 'INACTIVE', 'updated_date': '2018-06-12 16:40:00',
+             'nameserver': 'dummy2;dummy;dummy', 'admin_contact': 'admin2', 'tech_contact': 'tech2',
+             'billing_contact': 'billing2', 'owner_contact': 'owner2'},
+            {'name': 'domain3.nl', 'status': 'ACTIVE', 'updated_date': '2018-06-12 16:30:00',
+             'nameserver': 'dummy3;dummy;dummy', 'admin_contact': 'admin3', 'tech_contact': 'tech3',
+             'billing_contact': 'billing3', 'owner_contact': 'owner3'},
+        ])


### PR DESCRIPTION
Added a function to get last updated domains with extra information(domain name status, update date, nameservers, contacthandles). With an option to retrieve all of them and also the possibility to add any other argument(via **kwargs)

```
    def get_last_updated_domains_with_details(self, index=0, retrieve_all=False, time_between_calls_in_seconds=1, **kwargs):
        """
        Returns list of domains registered in your account with domain name, status, update_date,
        nameservers, admin_contact, tech_contact, billing_contact and owner_contact
        :param int index: Start results from this item
        :param bool retrieve_all: Setting this to true will return all domains in the account, otherwise
        this function will return the last 1000 updated domains
        :param int time_between_calls_in_seconds: Custom delay in seconds between calls
        """
        domain_list = self.query_domain_list(first=index, type='ALL', orderby='DOMAINUPDATEDDATE', order='DESC', **kwargs)
...
```

I also refactored `get_domain_list_from_account` since it was using a similar logic. 

I also want to get rid of the `time_in_between_calls` to make it more generic(inside `call`) instead of this function, but I'll do that in another PR